### PR TITLE
fix: accumulate coverage across multiple curated lib hits per query before threshold check

### DIFF
--- a/tetrimmer/functions.py
+++ b/tetrimmer/functions.py
@@ -2056,8 +2056,8 @@ def repeatmasker(genome_file, library_file, output_dir, thread=1, classify=False
             '-a',  # Writes alignments in .align output file
         ]
 
-        if no_low:
-            command.append('-nolow')
+    if no_low:
+        command.append('-nolow')
 
     # Set env variable for RepeatMasker
     env = os.environ.copy()
@@ -2203,7 +2203,7 @@ def repeatmasker_output_classify(
 
 
 def eliminate_curatedlib_by_repeatmasker(
-    curatedlib, input_seq, curatedlib_dir, min_iden=95, min_cov=95, num_threads=10
+    curatedlib, input_seq, curatedlib_dir, min_iden=80, min_cov=80, num_threads=10
 ):
     # For the repeatmasker_out --input_seq as genome, --curatedlib serves as repeat database
     # Define the directory
@@ -2338,9 +2338,26 @@ def eliminate_curatedlib_by_repeatmasker(
         return False
 
     try:
-        # Filter dataframe according to the percentage of coverage
-        df = df[df['cov_query_perc'] >= min_cov]
-        #df = df[df['cov_repeat_perc'] >= min_cov]
+        # Merge overlapping intervals per query to get total unique coverage
+        df = df.sort_values(['query_name', 'query_start'])
+
+        def merge_intervals(group):
+            intervals = sorted(zip(group['query_start'], group['query_end']))
+            merged = []
+            for start, end in intervals:
+                if merged and start <= merged[-1][1]:
+                    merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+                else:
+                    merged.append((start, end))
+            total_cov = sum(end - start for start, end in merged)
+            return pd.Series({
+                'total_cov_len': total_cov,
+                'query_len': group['query_len'].iloc[0],
+            })
+
+        grouped = df.groupby('query_name', sort=False).apply(merge_intervals, include_groups=False)
+        grouped['cov_query_perc'] = grouped['total_cov_len'] / grouped['query_len'] * 100
+        grouped = grouped[grouped['cov_query_perc'] >= min_cov]
 
     except Exception:
         logging.warning(
@@ -2349,7 +2366,7 @@ def eliminate_curatedlib_by_repeatmasker(
         return False
 
     try:
-        if df.empty:
+        if grouped.empty:
             logging.warning(
                 'No sequences are found in --input_file that are identical to the sequences in --curatedlib'
             )
@@ -2361,10 +2378,10 @@ def eliminate_curatedlib_by_repeatmasker(
                 curatedlib_dir,
                 f'{os.path.basename(input_seq)}_curatedlib_filtered_RepeatMasker.txt',
             )
-            df.to_csv(df_file, sep='\t', index=False)
+            grouped.reset_index().to_csv(df_file, sep='\t', index=False)
 
             # Group dataframe by 'query_name' and extract unique query names
-            unique_query_names = df['query_name'].unique().tolist()
+            unique_query_names = grouped.index.tolist()
             # print(unique_query_names)
 
             logging.info(


### PR DESCRIPTION
eliminate_curatedlib_by_repeatmasker():
- Replace per-row coverage filter (each hit needed >=95% alone) with interval merging per query to accumulate total unique coverage
- Set "min_iden=80, min_cov=80" to reflect 80/80/80 standard
- Add "include_groups=False" to "groupby().apply()" to fix FutureWarning from pandas

repeatmasker():
- Move "if no_low: command.append('-nolow')" outside the "else:" block so it applies when "classify=True" too (was silently ignored)